### PR TITLE
Ensure all dist files are included in NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,7 @@
 *
 
 # include these:
-!dist
+!dist/**/*
 !LICENSE
 !README.md
 


### PR DESCRIPTION
Hey @Y-developer, apologies about this -- it looks like I missed the npmignore in my previous PR, so it means that 2.2.1 is still missing the typings. This PR should fix that (you can confirm locally with `npm run build && npm publish --dry-run`, which should show both `dist/index.js` and `dist/index.d.ts`).